### PR TITLE
Margauxmedwards/team-size-clarification

### DIFF
--- a/general-rules.adoc
+++ b/general-rules.adoc
@@ -26,6 +26,8 @@ server: https://robocup-junior.github.io/soccer-rules/discord/[Discord Server Li
 
 * OnStage League: 5 members.
 
+Regional and SuperRegional competitions may define their own team sizes depending on their venue capacity and regional variations. Teams attending the International competition will only be able to have the maximum number of registered participants in the qualifying team.
+
 *Shared Members and Robots*: No team member(s) or robot(s) may be
 shared between teams.
 

--- a/general-rules.adoc
+++ b/general-rules.adoc
@@ -199,23 +199,25 @@ organizers of all Junior and Major Leagues as well as the host venue.
 ==== Code of Conduct
 All organisers, volunteers, team members, mentors, supporters and visitors must abide by the RoboCup Federation Code of Conduct. Any instances where, a situation occurs that does not meet the code of conduct must be reported to a RoboCup Federation organisation member and will be investigated.
 
-==== Mentoring, Sponsorships and Component Reuse
-
+==== Mentoring and Onsite Assistance
 Support from other teams, mentors, teachers, parents, sponsors, internet
-communities etc. is a core part of how teams learn and grow. To ensure fair
-competition and maximize learning it is required that none of the support they
+communities etc. is a core part of how teams learn and grow.
+
+To ensure fair competition and maximize learning it is required that none of the support they
 receive does the work of competing for the team. A good indication is the team's
 ability to explain not only what their robots' components do but also how they
 do it.
 
-==== Onsite help
-
-Teams are only allowed to receive help from other teams during the competition.
-To this end only student team members are allowed into the student work area
-except with temporary organizer permission. Anyone else is forbidden from
-touching the robots or their code, especially for repairs, changes, programming.
+==== Teams Onsite
+* During the competition, only the official team members (maximum 4/5 depending on league) 
+can represent the team at registration, setup-day, and have access to the competition areas for rounds and interviews. 
+* There must be at least 2 team members on-site, unless a team can present evidence of extenuating circumstances, including proof of travel for other team members. Teams where only one participant presents at the venue will be able to compete, but will not be eligible for finals or awards. 
+* It is the teams' responsibility to ensure that team member are present at the correct time and location for all scheduled activities.
+* Teams are not allowed to communicate with or receive help virtually from external parties with the intention of impacting the team's performance during the competition areas. Virtually communicating includes but is not limited to extended phone calls, video calls, remote desktop control etc.
+* Any team found to be in breach of these rules may be subject to disciplinary action.
+* Teams are recommended  to seek help from other teams, or organizers if they are struggling with any issues onsite.
 
 ==== Violations
 
-Teams that repeatedly conduct themselves in an unacceptable way may be
+Teams, Team Mentors/Supporters or Team Members that repeatedly conduct themselves in an unacceptable way or in violation to the General or League Rules may be
 disqualified from the tournament and asked to leave the venue.

--- a/general-rules.adoc
+++ b/general-rules.adoc
@@ -29,8 +29,16 @@ server: https://robocup-junior.github.io/soccer-rules/discord/[Discord Server Li
 *Shared Members and Robots*: No team member(s) or robot(s) may be
 shared between teams.
 
+==== Team Supervision
 *Junior Mentor Requirement*: Each Junior team must have at least 
 one Junior Mentor registered and attending with the team.
+
+Mentors and Parent/Chaperones are responsible for supervising their teams
+and maintain a duty of care/well being for their team members, as appropriate for their home region's regulations.
+Any concerns regarding team member welfare should be brought to the attention of the event organizers immediately.
+
+The Junior Mentor is expected to be present during all official competition events with their team.
+They must not interact in an imposing manner with teams, robots, judges, or the judging process. Any incident considered inappropriate will be handled by the event organizers and may lead to disciplinary actions.
 
 ==== Age Requirements
 
@@ -187,6 +195,9 @@ league documentation submissions for the international competition.
 All participants are expected to behave themselves and be considerate and polite
 especially but not only towards other participants, volunteers, referees and
 organizers of all Junior and Major Leagues as well as the host venue.
+
+==== Code of Conduct
+All organisers, volunteers, team members, mentors, supporters and visitors must abide by the RoboCup Federation Code of Conduct. Any instances where, a situation occurs that does not meet the code of conduct must be reported to a RoboCup Federation organisation member and will be investigated.
 
 ==== Mentoring, Sponsorships and Component Reuse
 

--- a/general-rules.adoc
+++ b/general-rules.adoc
@@ -1,4 +1,4 @@
-== RoboCupJunior International 2025 General Rules
+== RoboCupJunior International 2026 General Rules
 
 These rules apply to the international RoboCupJunior competition.
 However, regional, super-regional, and local tournaments may have
@@ -10,6 +10,10 @@ be in use.
 If teams are unsure about any aspects of the General Rules or specific
 League Rules, they are encouraged to inquire via the official
 RoboCupJunior Forum for clarification: https://junior.forum.robocup.org/
+
+For questions regarding any of the rules or RoboCupJunior in general, teams
+can also reach out to the RoboCupJunior community through the official discord
+server: https://robocup-junior.github.io/soccer-rules/discord/[Discord Server Link]
 
 === Team requirements
 
@@ -102,7 +106,7 @@ functionality.
 Actuators must be appropriate for the robot’s size and function.
 
 * *Hazardous Behavior*: Teams must report potentially dangerous robot
-behaviors at least two weeks before the event.
+behaviors at least two weeks before a RoboCupJunior event.
 
 === Documentation and Sharing requirements
 

--- a/general-rules.adoc
+++ b/general-rules.adoc
@@ -46,6 +46,15 @@ competition but feature in many regions and SuperRegional tournaments.
 role (mechanical/design, electrical/sensing, software etc.) and should
 be able to explain their role during technical judging.
 
+=== International Team Qualification Process
+* To qualify for the International competition, each region’s Regional Representative will complete the Slot Allocation Process at the start of the Competition year. Regional Representatives can be found at https://junior.robocup.org/gettingstarted/[Regional Representatives].
+* After the region’s local qualifying tournament, the Regional Representative 
+will assign slots. Once confirmed by the RoboCupJunior organizers, the qualified teams will be invited to register through the official RoboCup Federation registration system.
+* The qualification process differs depending on the size of each region, 
+but slot allocation must strongly reflect results from regional competitions.
+* If a region does not use or releases its allocated slots, Regional Representatives 
+may request additional slots during a later stage of the allocation process.
+
 === Robot Requirements
 
 ==== Robot Communication


### PR DESCRIPTION
Added Regional team size notice to allow regions to have more freedom over team size. This came at the bequest of the soccer community, and allows larger teams, particularly new regional teams to be larger. International team size will not change for 2026, but will be looked at during the 2026 season.